### PR TITLE
Fix typo in integration test filename

### DIFF
--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class PriceControlerIT {
+public class PriceControllerIT {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- rename `PriceControlerIT` integration test to `PriceControllerIT`
- update class declaration accordingly

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68400abb3548832da160de4f13f4d323