### PR TITLE
Fix field name extraction in validation handler

### DIFF
--- a/src/main/java/com/miempresa/priceapplication/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/miempresa/priceapplication/exception/GlobalExceptionHandler.java
@@ -19,9 +19,14 @@ public class GlobalExceptionHandler  {
     public ResponseEntity<Map<String, String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach(error -> {
-            String fieldName = ((FieldError) error).getField();
+            String key;
+            if (error instanceof FieldError) {
+                key = ((FieldError) error).getField();
+            } else {
+                key = error.getObjectName();
+            }
             String errorMessage = error.getDefaultMessage();
-            errors.put(fieldName, errorMessage);
+            errors.put(key, errorMessage);
         });
         Map<String, String> response = new HashMap<>();
         response.put("error", "Invalid Request");  // Keep this consistent with your expectations


### PR DESCRIPTION
## Summary
- check error type in `handleMethodArgumentNotValid` before casting

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68400bd50dfc832d910c746be2e2d36b