### PR TITLE
Clarify date parameter format

### DIFF
--- a/src/main/java/com/miempresa/priceapplication/service/PriceService.java
+++ b/src/main/java/com/miempresa/priceapplication/service/PriceService.java
@@ -26,7 +26,7 @@ public class PriceService {
      *
      * @param productId El ID del producto.
      * @param brandId El ID de la marca.
-     * @param date La fecha en formato LocalDateTime.
+     * @param date La fecha como cadena en formato ISO 8601 ("YYYY-MM-DDTHH:MM:SS").
      * @return Una lista de precios aplicables.
      */
     public List<Price> getApplicablePrices(Integer productId, Integer brandId, String date) {


### PR DESCRIPTION
## Summary
- clarify format of `date` parameter in the service Javadoc

## Testing
- `mvn -q test` *(fails: unable to resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68400bd69df4832db43e7e4f2901359b