### PR TITLE
Add JSON list size checks in PriceController tests

### DIFF
--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.hasSize;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -51,6 +52,7 @@ public class PriceControllerTest {
                         .param("brandId", "1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].price").value(35.5))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));
@@ -65,6 +67,7 @@ public class PriceControllerTest {
                         .param("brandId", "1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].price").value(25.45))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));
@@ -79,6 +82,7 @@ public class PriceControllerTest {
                         .param("brandId", "1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].price").value(35.50))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));
@@ -93,6 +97,7 @@ public class PriceControllerTest {
                         .param("brandId", "1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].price").value(30.50))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));
@@ -107,6 +112,7 @@ public class PriceControllerTest {
                         .param("brandId", "1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].price").value(38.95))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));


### PR DESCRIPTION
## Summary
- update `PriceControllerTest` to verify only one price is returned
- import `hasSize` matcher

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68400bda76a4832d9073db89687c8c46