### PR TITLE
Add delete endpoint for prices

### DIFF
--- a/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
+++ b/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
@@ -64,4 +64,15 @@ public class PriceController {
             @RequestParam @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime date) {
         return ResponseEntity.ok(priceService.getApplicablePrices(productId, brandId, date));
     }
+
+    @Operation(summary = "Eliminar un precio", description = "Elimina un precio existente por su ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Precio eliminado exitosamente", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Precio no encontrado", content = @Content)
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePrice(@PathVariable @Min(1) Long id) {
+        priceService.deletePrice(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/miempresa/priceapplication/service/PriceService.java
+++ b/src/main/java/com/miempresa/priceapplication/service/PriceService.java
@@ -76,4 +76,19 @@ public class PriceService {
             throw new InvalidPriceRequestException("Error saving the price. Please verify the data.");
         }
     }
+
+    /**
+     * Elimina un precio por su identificador.
+     *
+     * @param id identificador del precio a eliminar
+     * @throws PriceNotFoundException si no existe el precio con el id proporcionado
+     */
+    public void deletePrice(Long id) {
+        log.debug("Attempting to delete price with id {}", id);
+        Price price = priceRepository.findById(id)
+                .orElseThrow(() -> new PriceNotFoundException("Price with id " + id + " not found"));
+
+        priceRepository.delete(price);
+        log.info("Price deleted successfully: {}", id);
+    }
 }

--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
@@ -2,6 +2,7 @@ package com.miempresa.priceapplication.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.miempresa.priceapplication.model.Price;
+import com.miempresa.priceapplication.repository.PriceRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,9 +14,11 @@ import java.time.LocalDateTime;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -26,6 +29,9 @@ public class PriceControllerIT {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private PriceRepository priceRepository;
 
     @Test
     public void whenGetPrice_thenReturnPrice() throws Exception {
@@ -130,6 +136,17 @@ public class PriceControllerIT {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("Invalid Request"))
                 .andExpect(jsonPath("$.message").value("The price for this product, brand, and date already exists."));
+    }
+
+    @Test
+    public void whenDeletePrice_thenStatus204() throws Exception {
+        Price price = new Price(null, 1, LocalDateTime.now().plusMinutes(2), LocalDateTime.now().plusDays(2), 99, 88888, 0, 10.0, "EUR");
+        price = priceRepository.save(price);
+
+        mockMvc.perform(delete("/api/prices/{id}", price.getId()))
+                .andExpect(status().isNoContent());
+
+        assertFalse(priceRepository.findById(price.getId()).isPresent());
     }
 
 

--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
@@ -13,9 +13,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -116,5 +118,19 @@ public class PriceControllerTest {
                 .andExpect(jsonPath("$[0].price").value(38.95))
                 .andExpect(jsonPath("$[0].brandId").value(1))
                 .andExpect(jsonPath("$[0].productId").value(35455));
+    }
+
+    @Test
+    public void testDeleteExistingPrice() throws Exception {
+        Long idToDelete = 1L;
+        mockMvc.perform(delete("/api/prices/{id}", idToDelete))
+                .andExpect(status().isNoContent());
+        assertFalse(priceRepository.findById(idToDelete).isPresent());
+    }
+
+    @Test
+    public void testDeleteNonExistingPrice() throws Exception {
+        mockMvc.perform(delete("/api/prices/{id}", 999L))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## Summary
- implement deletePrice in service layer
- expose DELETE /api/prices/{id}
- cover deletion with unit/integration tests

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684025694bd4832dbbd999e2b1b4d85d