### PR TITLE
Implement update endpoint for Price

### DIFF
--- a/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
+++ b/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
@@ -75,4 +75,18 @@ public class PriceController {
         priceService.deletePrice(id);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "Actualizar un precio", description = "Actualiza un precio existente")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Precio actualizado exitosamente",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Price.class)) }),
+            @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Precio no encontrado", content = @Content)
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<Price> updatePrice(@PathVariable @Min(1) Long id,
+                                             @Valid @RequestBody Price price) {
+        Price updatedPrice = priceService.updatePrice(id, price);
+        return ResponseEntity.ok(updatedPrice);
+    }
 }

--- a/src/main/java/com/miempresa/priceapplication/service/PriceService.java
+++ b/src/main/java/com/miempresa/priceapplication/service/PriceService.java
@@ -93,4 +93,36 @@ public class PriceService {
         priceRepository.delete(price);
         log.info("Price deleted successfully: {}", id);
     }
+
+    /**
+     * Actualiza un precio existente.
+     *
+     * @param id    identificador del precio a actualizar
+     * @param price datos nuevos del precio
+     * @return el precio actualizado
+     */
+    public Price updatePrice(Long id, Price price) {
+        log.debug("Attempting to update price with id {}", id);
+
+        Price existingPrice = priceRepository.findById(id)
+                .orElseThrow(() -> new PriceNotFoundException("Price with id " + id + " not found"));
+
+        Optional<Price> duplicate = priceRepository.findByProductIdAndBrandIdAndStartDate(
+                price.getProductId(), price.getBrandId(), price.getStartDate());
+
+        if (duplicate.isPresent() && !duplicate.get().getId().equals(id)) {
+            log.error("Price already exists for this product, brand, and date: {}", duplicate.get());
+            throw new InvalidPriceRequestException("The price for this product, brand, and date already exists.");
+        }
+
+        try {
+            price.setId(id);
+            Price savedPrice = priceRepository.save(price);
+            log.info("Price updated successfully: {}", savedPrice);
+            return savedPrice;
+        } catch (Exception e) {
+            log.error("Error updating the price: {}", e.getMessage(), e);
+            throw new PriceServiceException("Error updating the price. Please verify the data.");
+        }
+    }
 }

--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -147,6 +148,20 @@ public class PriceControllerIT {
                 .andExpect(status().isNoContent());
 
         assertFalse(priceRepository.findById(price.getId()).isPresent());
+    }
+
+    @Test
+    public void whenUpdatePrice_thenStatus200() throws Exception {
+        Price price = new Price(null, 1, LocalDateTime.now().plusMinutes(5), LocalDateTime.now().plusDays(3), 100, 77777, 0, 10.0, "EUR");
+        price = priceRepository.save(price);
+
+        Price updated = new Price(null, 1, price.getStartDate(), price.getEndDate(), price.getPriceList(), price.getProductId(), 0, 20.0, "EUR");
+
+        mockMvc.perform(put("/api/prices/{id}", price.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updated)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.price").value(20.0));
     }
 
 

--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerTest.java
@@ -1,5 +1,6 @@
 package com.miempresa.priceapplication.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.miempresa.priceapplication.model.Price;
 import com.miempresa.priceapplication.repository.PriceRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.hamcrest.Matchers.hasSize;
@@ -135,6 +137,33 @@ public class PriceControllerTest {
     @Test
     public void testDeleteNonExistingPrice() throws Exception {
         mockMvc.perform(delete("/api/prices/{id}", 999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testUpdateExistingPrice() throws Exception {
+        Price updated = new Price(null, 1, LocalDateTime.of(2020, 6, 14, 0, 0),
+                LocalDateTime.of(2020, 12, 31, 23, 59), 1, 35455, 0, 40.0, "EUR");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        mockMvc.perform(put("/api/prices/{id}", existingPriceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(updated)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.price").value(40.0));
+    }
+
+    @Test
+    public void testUpdateNonExistingPrice() throws Exception {
+        Price updated = new Price(null, 1, LocalDateTime.of(2020, 6, 14, 0, 0),
+                LocalDateTime.of(2020, 12, 31, 23, 59), 1, 35455, 0, 40.0, "EUR");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        mockMvc.perform(put("/api/prices/{id}", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(updated)))
                 .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## Summary
- add `updatePrice` in `PriceService`
- expose `PUT /api/prices/{id}` in `PriceController`
- test updating prices in integration and controller tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840351dfcac832da9a2f1f623794141