### PR TITLE
Prevent overlapping price ranges

### DIFF
--- a/src/main/java/com/miempresa/priceapplication/repository/PriceRepository.java
+++ b/src/main/java/com/miempresa/priceapplication/repository/PriceRepository.java
@@ -22,9 +22,20 @@ public interface PriceRepository extends JpaRepository<Price, Long> {
                                      @Param("brandId") Integer brandId,
                                      @Param("date") LocalDateTime date);
 
+
     @Query("SELECT p FROM Price p WHERE p.productId = :productId AND p.brandId = :brandId AND p.startDate = :startDate")
     Optional<Price> findByProductIdAndBrandIdAndStartDate(@Param("productId") Integer productId,
                                                           @Param("brandId") Integer brandId,
                                                           @Param("startDate") LocalDateTime startDate);
+
+    @Query("SELECT p FROM Price p " +
+            "WHERE p.productId = :productId " +
+            "AND p.brandId = :brandId " +
+            "AND p.startDate < :endDate " +
+            "AND p.endDate > :startDate")
+    List<Price> findOverlappingPrices(@Param("productId") Integer productId,
+                                      @Param("brandId") Integer brandId,
+                                      @Param("startDate") LocalDateTime startDate,
+                                      @Param("endDate") LocalDateTime endDate);
 
 }

--- a/src/main/java/com/miempresa/priceapplication/service/PriceService.java
+++ b/src/main/java/com/miempresa/priceapplication/service/PriceService.java
@@ -2,6 +2,7 @@ package com.miempresa.priceapplication.service;
 
 import com.miempresa.priceapplication.exception.InvalidPriceRequestException;
 import com.miempresa.priceapplication.exception.PriceNotFoundException;
+import com.miempresa.priceapplication.exception.PriceServiceException;
 import com.miempresa.priceapplication.model.Price;
 import com.miempresa.priceapplication.repository.PriceRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +67,14 @@ public class PriceService {
         if (existingPrice.isPresent()) {
             log.error("Price already exists for this product, brand, and date: {}", existingPrice.get());
             throw new InvalidPriceRequestException("The price for this product, brand, and date already exists.");
+        }
+
+        List<Price> overlaps = priceRepository.findOverlappingPrices(
+                price.getProductId(), price.getBrandId(), price.getStartDate(), price.getEndDate());
+
+        if (!overlaps.isEmpty()) {
+            log.error("Overlapping prices found: {}", overlaps);
+            throw new InvalidPriceRequestException("The new price overlaps with an existing price range.");
         }
 
         log.debug("Saving new price...");

--- a/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
+++ b/src/test/java/com/miempresa/priceapplication/controller/PriceControllerIT.java
@@ -140,6 +140,21 @@ public class PriceControllerIT {
     }
 
     @Test
+    public void whenOverlappingPrice_thenStatus400() throws Exception {
+        Price overlapping = new Price(null, 1,
+                LocalDateTime.of(2020, 6, 15, 10, 0),
+                LocalDateTime.of(2020, 6, 20, 23, 59),
+                5, 35455, 0, 45.0, "EUR");
+
+        mockMvc.perform(post("/api/prices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(overlapping)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Invalid Request"))
+                .andExpect(jsonPath("$.message").value("The new price overlaps with an existing price range."));
+    }
+
+    @Test
     public void whenDeletePrice_thenStatus204() throws Exception {
         Price price = new Price(null, 1, LocalDateTime.now().plusMinutes(2), LocalDateTime.now().plusDays(2), 99, 88888, 0, 10.0, "EUR");
         price = priceRepository.save(price);


### PR DESCRIPTION
## Summary
- add a repository query to find overlapping prices
- validate overlapping ranges in `PriceService`
- test overlap scenario via controller integration tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68403705c9cc832db90ae4ec7ce1587f