### PR TITLE
Add Swagger configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,9 @@ git clone https://github.com/CesarAugustusGroB/PriceApp.git
 ```
 
 ### Swagger
-Puedes consultar la API en: http://localhost:8080/swagger-ui/index.html
+La documentación interactiva se encuentra disponible una vez arranque la aplicación.
+Abre tu navegador y navega a:
+
+```
+http://localhost:8080/swagger-ui.html
+```

--- a/src/main/java/com/miempresa/priceapplication/PriceApplication.java
+++ b/src/main/java/com/miempresa/priceapplication/PriceApplication.java
@@ -2,8 +2,12 @@ package com.miempresa.priceapplication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Price Application API", version = "1.0",
+        description = "API para la gestión de precios de productos"))
 public class PriceApplication {
 
     public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.jpa.show-sql=true
 logging.level.root=INFO
 logging.level.com.miempresa.priceapplication.service.PriceService=DEBUG
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
+
+# Configuración de Swagger (springdoc)
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary
- document Swagger UI location in README
- expose OpenAPI metadata with `@OpenAPIDefinition`
- configure Swagger paths in `application.properties`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684043e2b600832dbda10f8626671b0c