### PR TITLE
Integrate RabbitMQ messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Se dividen dos microservicios: **price-service** y **customer-service**. Ambos m
 - Validación de datos a través de anotaciones.
 - Base de datos en memoria H2.
 - Cobertura de pruebas unitarias e integradas.
+- Comunicación asíncrona mediante RabbitMQ.
 
 ## Tecnologías Utilizadas
 - **Java 17**
@@ -19,6 +20,7 @@ Se dividen dos microservicios: **price-service** y **customer-service**. Ambos m
 - **JPA (Java Persistence API)**
 - **Jakarta Validation**
 - **JUnit 5** y **Spring MockMvc** para pruebas
+- **RabbitMQ** para mensajería asíncrona
 
 ## Instalación y Ejecución
 
@@ -44,3 +46,9 @@ Abre tu navegador y navega a:
 ```
 http://localhost:8080/swagger-ui.html
 ```
+
+### Mensajería Asíncrona
+Se integró RabbitMQ como sistema de colas para propagar eventos de forma desacoplada.
+Los servicios publican mensajes en `price.events` y `customer.events` cuando se
+crean o actualizan registros, permitiendo que otros sistemas reaccionen sin
+bloquear la operación principal.

--- a/customer-service/pom.xml
+++ b/customer-service/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>

--- a/customer-service/src/main/java/com/miempresa/priceapplication/messaging/CustomerEventPublisher.java
+++ b/customer-service/src/main/java/com/miempresa/priceapplication/messaging/CustomerEventPublisher.java
@@ -1,0 +1,23 @@
+package com.miempresa.priceapplication.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishCustomerUpdated(Long customerId) {
+        try {
+            rabbitTemplate.convertAndSend("customer.events", "customer.updated", customerId);
+            log.info("Customer update event published: {}", customerId);
+        } catch (Exception e) {
+            log.warn("Failed to publish customer update event: {}", e.getMessage());
+        }
+    }
+}

--- a/customer-service/src/main/java/com/miempresa/priceapplication/service/CustomerService.java
+++ b/customer-service/src/main/java/com/miempresa/priceapplication/service/CustomerService.java
@@ -4,6 +4,7 @@ import com.miempresa.priceapplication.exception.CustomerNotFoundException;
 import com.miempresa.priceapplication.exception.CustomerServiceException;
 import com.miempresa.priceapplication.model.Customer;
 import com.miempresa.priceapplication.repository.CustomerRepository;
+import com.miempresa.priceapplication.messaging.CustomerEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.List;
 public class CustomerService {
 
     private final CustomerRepository customerRepository;
+    private final CustomerEventPublisher eventPublisher;
 
     public List<Customer> getAllCustomers() {
         log.debug("Fetching all customers");
@@ -32,17 +34,22 @@ public class CustomerService {
         if (customerRepository.existsByEmail(customer.getEmail())) {
             throw new CustomerServiceException("Email already exists");
         }
-        return customerRepository.save(customer);
+        Customer saved = customerRepository.save(customer);
+        eventPublisher.publishCustomerUpdated(saved.getId());
+        return saved;
     }
 
     public Customer updateCustomer(Long id, Customer customer) {
         Customer existing = getCustomer(id);
         customer.setId(existing.getId());
-        return customerRepository.save(customer);
+        Customer updated = customerRepository.save(customer);
+        eventPublisher.publishCustomerUpdated(updated.getId());
+        return updated;
     }
 
     public void deleteCustomer(Long id) {
         Customer existing = getCustomer(id);
         customerRepository.delete(existing);
+        eventPublisher.publishCustomerUpdated(id);
     }
 }

--- a/price-service/pom.xml
+++ b/price-service/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>

--- a/price-service/src/main/java/com/miempresa/priceapplication/messaging/PriceEventPublisher.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/messaging/PriceEventPublisher.java
@@ -1,0 +1,23 @@
+package com.miempresa.priceapplication.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PriceEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishPriceUpdated(Long priceId) {
+        try {
+            rabbitTemplate.convertAndSend("price.events", "price.updated", priceId);
+            log.info("Price update event published: {}", priceId);
+        } catch (Exception e) {
+            log.warn("Failed to publish price update event: {}", e.getMessage());
+        }
+    }
+}

--- a/price-service/src/main/java/com/miempresa/priceapplication/service/PriceService.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/service/PriceService.java
@@ -5,6 +5,7 @@ import com.miempresa.priceapplication.exception.PriceNotFoundException;
 import com.miempresa.priceapplication.exception.PriceServiceException;
 import com.miempresa.priceapplication.model.Price;
 import com.miempresa.priceapplication.repository.PriceRepository;
+import com.miempresa.priceapplication.messaging.PriceEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.Optional;
 public class PriceService {
 
     private final PriceRepository priceRepository;
+    private final PriceEventPublisher eventPublisher;
 
     /**
      * Obtiene los precios aplicables según el producto, marca y fecha proporcionados.
@@ -81,6 +83,7 @@ public class PriceService {
         try {
             Price savedPrice = priceRepository.save(price);
             log.info("Price saved successfully: {}", savedPrice);
+            eventPublisher.publishPriceUpdated(savedPrice.getId());
             return savedPrice;
         } catch (Exception e) {
             log.error("Error saving the price: {}", e.getMessage(), e);
@@ -101,6 +104,7 @@ public class PriceService {
 
         priceRepository.delete(price);
         log.info("Price deleted successfully: {}", id);
+        eventPublisher.publishPriceUpdated(id);
     }
 
     /**
@@ -128,6 +132,7 @@ public class PriceService {
             price.setId(id);
             Price savedPrice = priceRepository.save(price);
             log.info("Price updated successfully: {}", savedPrice);
+            eventPublisher.publishPriceUpdated(savedPrice.getId());
             return savedPrice;
         } catch (Exception e) {
             log.error("Error updating the price: {}", e.getMessage(), e);


### PR DESCRIPTION
## Summary
- add RabbitMQ starter to `price-service` and `customer-service`
- publish `PriceEvent` and `CustomerEvent` when data changes
- document async messaging in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6841b30e05d0832dab6de08cb13ca331