### PR TITLE
Add basic CQRS and event sourcing

### DIFF
--- a/price-service/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
@@ -1,7 +1,10 @@
 package com.miempresa.priceapplication.controller;
 
 import com.miempresa.priceapplication.model.Price;
-import com.miempresa.priceapplication.service.PriceService;
+import com.miempresa.priceapplication.model.PriceEvent;
+import com.miempresa.priceapplication.service.PriceCommandService;
+import com.miempresa.priceapplication.service.PriceQueryService;
+import com.miempresa.priceapplication.service.PriceEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,7 +34,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PriceController {
 
-    private final PriceService priceService;
+    private final PriceCommandService commandService;
+    private final PriceQueryService queryService;
+    private final PriceEventService eventService;
 
     @Operation(summary = "Crear un nuevo precio", description = "Crea un precio basado en los detalles proporcionados.")
     @ApiResponses(value = {
@@ -42,7 +47,7 @@ public class PriceController {
     @PostMapping
     public Mono<ResponseEntity<Price>> createPrice(@Valid @RequestBody Price price) {
         log.info("Solicitud de creación de precio recibida: {}", price);
-        return Mono.fromCallable(() -> priceService.createPrice(price))
+        return Mono.fromCallable(() -> commandService.createPrice(price))
                 .map(createdPrice -> {
                     log.info("Precio creado exitosamente: {}", createdPrice);
                     return ResponseEntity.status(201).body(createdPrice);
@@ -65,7 +70,7 @@ public class PriceController {
             @RequestParam @Min(1) Integer productId,
             @RequestParam @Min(1) Integer brandId,
             @RequestParam @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime date) {
-        return Mono.fromCallable(() -> priceService.getApplicablePrices(productId, brandId, date))
+        return Mono.fromCallable(() -> queryService.getApplicablePrices(productId, brandId, date))
                 .map(ResponseEntity::ok);
     }
 
@@ -76,7 +81,7 @@ public class PriceController {
     })
     @DeleteMapping("/{id}")
     public Mono<ResponseEntity<Void>> deletePrice(@PathVariable @Min(1) Long id) {
-        return Mono.fromRunnable(() -> priceService.deletePrice(id))
+        return Mono.fromRunnable(() -> commandService.deletePrice(id))
                 .then(Mono.just(ResponseEntity.noContent().build()));
     }
 
@@ -90,7 +95,14 @@ public class PriceController {
     @PutMapping("/{id}")
     public Mono<ResponseEntity<Price>> updatePrice(@PathVariable @Min(1) Long id,
                                              @Valid @RequestBody Price price) {
-        return Mono.fromCallable(() -> priceService.updatePrice(id, price))
+        return Mono.fromCallable(() -> commandService.updatePrice(id, price))
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Obtener eventos de un precio", description = "Devuelve el historial de eventos para un precio")
+    @GetMapping("/{id}/events")
+    public Mono<ResponseEntity<List<PriceEvent>>> getPriceEvents(@PathVariable @Min(1) Long id) {
+        return Mono.fromCallable(() -> eventService.getEvents(id))
                 .map(ResponseEntity::ok);
     }
 }

--- a/price-service/src/main/java/com/miempresa/priceapplication/model/PriceEvent.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/model/PriceEvent.java
@@ -1,0 +1,29 @@
+package com.miempresa.priceapplication.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class PriceEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long priceId;
+
+    private String eventType;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String eventData;
+
+    private LocalDateTime timestamp;
+}

--- a/price-service/src/main/java/com/miempresa/priceapplication/repository/PriceEventRepository.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/repository/PriceEventRepository.java
@@ -1,0 +1,12 @@
+package com.miempresa.priceapplication.repository;
+
+import com.miempresa.priceapplication.model.PriceEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PriceEventRepository extends JpaRepository<PriceEvent, Long> {
+    List<PriceEvent> findByPriceIdOrderByTimestampAsc(Long priceId);
+}

--- a/price-service/src/main/java/com/miempresa/priceapplication/service/PriceCommandService.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/service/PriceCommandService.java
@@ -10,55 +10,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
-public class PriceService {
+@Slf4j
+public class PriceCommandService {
 
     private final PriceRepository priceRepository;
     private final PriceEventPublisher eventPublisher;
+    private final PriceEventService eventService;
 
-    /**
-     * Obtiene los precios aplicables según el producto, marca y fecha proporcionados.
-     * Si no se encuentran precios, se lanza una excepción personalizada PriceNotFoundException.
-     *
-     * @param productId El ID del producto.
-     * @param brandId El ID de la marca.
-     * @param date La fecha como cadena en formato ISO 8601 ("YYYY-MM-DDTHH:MM:SS").
-     * @return Una lista de precios aplicables.
-     */
-    public List<Price> getApplicablePrices(Integer productId, Integer brandId, LocalDateTime date) {
-        log.info("Consultando precios para ProductID: {}, BrandID: {}, Fecha: {}", productId, brandId, date);
-        LocalDateTime dateTime = date;
-
-        List<Price> prices = priceRepository.findApplicablePrices(productId, brandId, dateTime);
-
-        if (prices.isEmpty()) {
-            log.warn("No se encontraron precios para ProductID: {}, BrandID: {}, Fecha: {}", productId, brandId, date);
-            throw new PriceNotFoundException("No se encontraron precios para el producto, marca y fecha proporcionados.");
-        }
-
-        log.info("Precios encontrados: {}", prices.size());
-        // Solo devolver el precio con mayor prioridad (primero de la lista)
-        Price selected = prices.get(0);
-        return List.of(selected);
-    }
-
-    /**
-     * Crea un nuevo registro de precio en la base de datos.
-     *
-     * Este método recibe un objeto {@link Price}, lo valida y lo almacena en la base de datos
-     * utilizando el repositorio de JPA. En caso de que el proceso de guardado falle, se registra
-     * un mensaje de error en los logs y se lanza una excepción personalizada.
-     *
-     * @param price El objeto {@link Price} que contiene los detalles del nuevo precio.
-     * @return El objeto {@link Price} almacenado en la base de datos con su ID generado.
-     * @throws InvalidPriceRequestException si ocurre un error durante el proceso de almacenamiento en la base de datos.
-     */
     public Price createPrice(Price price) {
         log.debug("Checking if price already exists for product {}, brand {}, startDate {}",
                 price.getProductId(), price.getBrandId(), price.getStartDate());
@@ -83,6 +46,7 @@ public class PriceService {
         try {
             Price savedPrice = priceRepository.save(price);
             log.info("Price saved successfully: {}", savedPrice);
+            eventService.recordEvent(savedPrice, "CREATED");
             eventPublisher.publishPriceUpdated(savedPrice.getId());
             return savedPrice;
         } catch (Exception e) {
@@ -91,12 +55,6 @@ public class PriceService {
         }
     }
 
-    /**
-     * Elimina un precio por su identificador.
-     *
-     * @param id identificador del precio a eliminar
-     * @throws PriceNotFoundException si no existe el precio con el id proporcionado
-     */
     public void deletePrice(Long id) {
         log.debug("Attempting to delete price with id {}", id);
         Price price = priceRepository.findById(id)
@@ -104,16 +62,10 @@ public class PriceService {
 
         priceRepository.delete(price);
         log.info("Price deleted successfully: {}", id);
+        eventService.recordEvent(price, "DELETED");
         eventPublisher.publishPriceUpdated(id);
     }
 
-    /**
-     * Actualiza un precio existente.
-     *
-     * @param id    identificador del precio a actualizar
-     * @param price datos nuevos del precio
-     * @return el precio actualizado
-     */
     public Price updatePrice(Long id, Price price) {
         log.debug("Attempting to update price with id {}", id);
 
@@ -132,6 +84,7 @@ public class PriceService {
             price.setId(id);
             Price savedPrice = priceRepository.save(price);
             log.info("Price updated successfully: {}", savedPrice);
+            eventService.recordEvent(savedPrice, "UPDATED");
             eventPublisher.publishPriceUpdated(savedPrice.getId());
             return savedPrice;
         } catch (Exception e) {

--- a/price-service/src/main/java/com/miempresa/priceapplication/service/PriceEventService.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/service/PriceEventService.java
@@ -1,0 +1,36 @@
+package com.miempresa.priceapplication.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miempresa.priceapplication.model.Price;
+import com.miempresa.priceapplication.model.PriceEvent;
+import com.miempresa.priceapplication.repository.PriceEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PriceEventService {
+
+    private final PriceEventRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public void recordEvent(Price price, String type) {
+        try {
+            String data = objectMapper.writeValueAsString(price);
+            PriceEvent event = new PriceEvent(null, price.getId(), type, data, LocalDateTime.now());
+            repository.save(event);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize price event: {}", e.getMessage());
+        }
+    }
+
+    public List<PriceEvent> getEvents(Long priceId) {
+        return repository.findByPriceIdOrderByTimestampAsc(priceId);
+    }
+}

--- a/price-service/src/main/java/com/miempresa/priceapplication/service/PriceQueryService.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/service/PriceQueryService.java
@@ -1,0 +1,35 @@
+package com.miempresa.priceapplication.service;
+
+import com.miempresa.priceapplication.exception.PriceNotFoundException;
+import com.miempresa.priceapplication.model.Price;
+import com.miempresa.priceapplication.repository.PriceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PriceQueryService {
+
+    private final PriceRepository priceRepository;
+
+    public List<Price> getApplicablePrices(Integer productId, Integer brandId, LocalDateTime date) {
+        log.info("Consultando precios para ProductID: {}, BrandID: {}, Fecha: {}", productId, brandId, date);
+        LocalDateTime dateTime = date;
+
+        List<Price> prices = priceRepository.findApplicablePrices(productId, brandId, dateTime);
+
+        if (prices.isEmpty()) {
+            log.warn("No se encontraron precios para ProductID: {}, BrandID: {}, Fecha: {}", productId, brandId, date);
+            throw new PriceNotFoundException("No se encontraron precios para el producto, marca y fecha proporcionados.");
+        }
+
+        log.info("Precios encontrados: {}", prices.size());
+        Price selected = prices.get(0);
+        return List.of(selected);
+    }
+}

--- a/price-service/src/main/resources/application.properties
+++ b/price-service/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 logging.level.root=INFO
-logging.level.com.miempresa.priceapplication.service.PriceService=DEBUG
+logging.level.com.miempresa.priceapplication.service=DEBUG
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
 
 # Configuración de Swagger (springdoc)


### PR DESCRIPTION
## Summary
- implement CQRS with new command & query services
- record price events for audit trail
- expose API endpoint to fetch price events

## Testing
- `mvn -q -pl price-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf5aaae8832d9ead690d8e754125