### PR TITLE
Add AWS Lambda example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,6 @@ kubectl apply -f k8s/
 ```
 
 Esto desplegará los servicios y expondrá el `gateway-service` como punto de entrada.
+
+### Integración Serverless (AWS Lambda)
+Para tareas puntuales, como notificaciones, auditorías o trabajos programados, puedes usar funciones Lambda. En la carpeta [`lambda`](lambda/) se incluye un ejemplo sencillo que puede desplegarse con la AWS CLI o mediante el framework Serverless.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,0 +1,19 @@
+# AWS Lambda Functions
+
+Este directorio contiene funciones Lambda de ejemplo para realizar tareas puntuales u operaciones programadas.
+
+`notificationHandler.js` muestra cómo recibir eventos y procesarlos para enviar notificaciones o ejecutar auditorías en tiempo real.
+
+Puedes desplegar la función con la AWS CLI:
+
+```bash
+zip function.zip notificationHandler.js
+aws lambda create-function \
+  --function-name notificationHandler \
+  --runtime nodejs18.x \
+  --handler notificationHandler.handler \
+  --role <ARN_ROLE_LAMBDA> \
+  --zip-file fileb://function.zip
+```
+
+También puedes utilizar el framework **Serverless** para automatizar la configuración y el despliegue.

--- a/lambda/notificationHandler.js
+++ b/lambda/notificationHandler.js
@@ -1,0 +1,8 @@
+exports.handler = async (event) => {
+    console.log('Received event:', JSON.stringify(event));
+    // Procesar el evento y ejecutar tareas como notificaciones o auditorías
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'Event processed' })
+    };
+};


### PR DESCRIPTION
## Summary
- add a minimal Node.js lambda example in `lambda/`
- document serverless integration in the main README

## Testing
- `mvn -pl price-service test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842a15f3594832da27751cd401b0459