### PR TITLE
Add Jenkins pipeline and IaC examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ build/
 
 ### Mac OS ###
 .DS_Store
+# Terraform
+.terraform/
+terraform.tfstate*
+# Ansible
+*.retry

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,49 @@
+pipeline {
+    agent any
+    environment {
+        REGISTRY = "myrepo"
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Build & Test') {
+            steps {
+                sh 'mvn -B clean verify'
+            }
+        }
+        stage('Build Docker Images') {
+            steps {
+                script {
+                    def modules = ['price-service','customer-service','gateway-service','config-server','discovery-server']
+                    for (m in modules) {
+                        sh "docker build -t $REGISTRY/${m}:${BUILD_NUMBER} ${m}"
+                    }
+                }
+            }
+        }
+        stage('Push Images') {
+            steps {
+                script {
+                    def modules = ['price-service','customer-service','gateway-service','config-server','discovery-server']
+                    for (m in modules) {
+                        sh "docker push $REGISTRY/${m}:${BUILD_NUMBER}"
+                    }
+                }
+            }
+        }
+        stage('Deploy to Kubernetes') {
+            steps {
+                sh 'kubectl apply -f k8s/'
+            }
+        }
+    }
+    post {
+        failure {
+            echo 'Deployment failed - rolling back'
+            sh 'kubectl rollout undo deployment/gateway-service || true'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ Esto desplegará los servicios y expondrá el `gateway-service` como punto de en
 
 ### Integración Serverless (AWS Lambda)
 Para tareas puntuales, como notificaciones, auditorías o trabajos programados, puedes usar funciones Lambda. En la carpeta [`lambda`](lambda/) se incluye un ejemplo sencillo que puede desplegarse con la AWS CLI o mediante el framework Serverless.
+
+### Automatizacion DevOps
+Se incluye un `Jenkinsfile` de ejemplo que compila el proyecto con Maven, ejecuta las pruebas y construye las imagenes Docker de cada servicio. Posteriormente las publica en un registro y despliega en Kubernetes. Ante fallos la tuberia realiza *rollback* sobre el despliegue.
+
+Asimismo, en la carpeta [`iac`](iac/) se proveen ejemplos de infraestructura como codigo:
+- [`terraform`](iac/terraform/) crea recursos de Kubernetes de manera reproducible.
+- [`ansible`](iac/ansible/) aplica los manifiestos y orquesta los despliegues.

--- a/iac/ansible/README.md
+++ b/iac/ansible/README.md
@@ -1,0 +1,7 @@
+# Ansible
+
+El playbook `deploy.yml` aplica los manifiestos de Kubernetes utilizando el módulo `kubernetes.core.k8s`. Define un host `kube` en tu inventario y proporciona la ruta al `kubeconfig` mediante la variable `kubeconfig`.
+
+```bash
+ansible-playbook -i inventory deploy.yml -e kubeconfig=~/.kube/config
+```

--- a/iac/ansible/deploy.yml
+++ b/iac/ansible/deploy.yml
@@ -1,0 +1,14 @@
+---
+- hosts: kube
+  tasks:
+    - name: Desplegar manifiestos de Kubernetes
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        src: "{{ item }}"
+      loop:
+        - ../../k8s/discovery-server.yaml
+        - ../../k8s/config-server.yaml
+        - ../../k8s/price-service.yaml
+        - ../../k8s/customer-service.yaml
+        - ../../k8s/gateway-service.yaml

--- a/iac/terraform/README.md
+++ b/iac/terraform/README.md
@@ -1,0 +1,9 @@
+# Terraform
+
+Este ejemplo utiliza el proveedor de Kubernetes para crear un namespace dedicado para los microservicios. Ajusta la variable `kubeconfig` con la ruta a tu configuracion de acceso al cluster.
+
+```bash
+cd iac/terraform
+terraform init
+terraform apply
+```

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig
+}
+
+variable "kubeconfig" {
+  description = "Ruta al archivo kubeconfig"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+resource "kubernetes_namespace" "priceapp" {
+  metadata {
+    name = "priceapp"
+  }
+}


### PR DESCRIPTION
## Summary
- document DevOps automation
- add a Jenkinsfile with build, test, deploy and rollback stages
- provide Terraform and Ansible examples for Kubernetes
- ignore Terraform and Ansible temporary files

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a24a0c54832da2faf497e47c57ac