### PR TITLE
Add simple price prediction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Esto desplegará los servicios y expondrá el `gateway-service` como punto de en
 ### Integración Serverless (AWS Lambda)
 Para tareas puntuales, como notificaciones, auditorías o trabajos programados, puedes usar funciones Lambda. En la carpeta [`lambda`](lambda/) se incluye un ejemplo sencillo que puede desplegarse con la AWS CLI o mediante el framework Serverless.
 
+### Machine Learning y Análisis de Datos
+Se añadió un endpoint de predicción en `price-service` que calcula precios sugeridos a partir del historial mediante un modelo de regresión lineal simple. Puedes consultarlo en `/api/prices/predict` enviando `productId`, `brandId` y la `date` objetivo.
+
 ### Automatizacion DevOps
 Se incluye un `Jenkinsfile` de ejemplo que compila el proyecto con Maven, ejecuta las pruebas y construye las imagenes Docker de cada servicio. Posteriormente las publica en un registro y despliega en Kubernetes. Ante fallos la tuberia realiza *rollback* sobre el despliegue.
 

--- a/price-service/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/controller/PriceController.java
@@ -5,6 +5,7 @@ import com.miempresa.priceapplication.model.PriceEvent;
 import com.miempresa.priceapplication.service.PriceCommandService;
 import com.miempresa.priceapplication.service.PriceQueryService;
 import com.miempresa.priceapplication.service.PriceEventService;
+import com.miempresa.priceapplication.service.PricePredictionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,6 +24,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 import java.util.List;
 
@@ -37,6 +39,7 @@ public class PriceController {
     private final PriceCommandService commandService;
     private final PriceQueryService queryService;
     private final PriceEventService eventService;
+    private final PricePredictionService predictionService;
 
     @Operation(summary = "Crear un nuevo precio", description = "Crea un precio basado en los detalles proporcionados.")
     @ApiResponses(value = {
@@ -96,6 +99,16 @@ public class PriceController {
     public Mono<ResponseEntity<Price>> updatePrice(@PathVariable @Min(1) Long id,
                                              @Valid @RequestBody Price price) {
         return Mono.fromCallable(() -> commandService.updatePrice(id, price))
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Predecir precio dinámico", description = "Utiliza aprendizaje automático sencillo para sugerir un precio basado en el historial")
+    @GetMapping("/predict")
+    public Mono<ResponseEntity<BigDecimal>> predictPrice(
+            @RequestParam @Min(1) Integer productId,
+            @RequestParam @Min(1) Integer brandId,
+            @RequestParam @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime date) {
+        return Mono.fromCallable(() -> predictionService.predictPrice(productId, brandId, date))
                 .map(ResponseEntity::ok);
     }
 

--- a/price-service/src/main/java/com/miempresa/priceapplication/repository/PriceRepository.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/repository/PriceRepository.java
@@ -38,4 +38,8 @@ public interface PriceRepository extends JpaRepository<Price, Long> {
                                       @Param("startDate") LocalDateTime startDate,
                                       @Param("endDate") LocalDateTime endDate);
 
+    @Query("SELECT p FROM Price p WHERE p.productId = :productId AND p.brandId = :brandId ORDER BY p.startDate ASC")
+    List<Price> findByProductIdAndBrandIdOrderByStartDateAsc(@Param("productId") Integer productId,
+                                                             @Param("brandId") Integer brandId);
+
 }

--- a/price-service/src/main/java/com/miempresa/priceapplication/service/PricePredictionService.java
+++ b/price-service/src/main/java/com/miempresa/priceapplication/service/PricePredictionService.java
@@ -1,0 +1,67 @@
+package com.miempresa.priceapplication.service;
+
+import com.miempresa.priceapplication.exception.PriceNotFoundException;
+import com.miempresa.priceapplication.model.Price;
+import com.miempresa.priceapplication.repository.PriceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PricePredictionService {
+
+    private final PriceRepository priceRepository;
+
+    public BigDecimal predictPrice(Integer productId, Integer brandId, LocalDateTime date) {
+        List<Price> prices = priceRepository.findByProductIdAndBrandIdOrderByStartDateAsc(productId, brandId);
+        if (prices.isEmpty()) {
+            throw new PriceNotFoundException("No price history for prediction");
+        }
+
+        // Convert dates to epoch seconds and prices to double
+        int n = prices.size();
+        double[] x = new double[n];
+        double[] y = new double[n];
+        for (int i = 0; i < n; i++) {
+            Price p = prices.get(i);
+            x[i] = p.getStartDate().toEpochSecond(ZoneOffset.UTC);
+            y[i] = p.getPrice().doubleValue();
+        }
+
+        double meanX = 0;
+        double meanY = 0;
+        for (int i = 0; i < n; i++) {
+            meanX += x[i];
+            meanY += y[i];
+        }
+        meanX /= n;
+        meanY /= n;
+
+        double numerator = 0;
+        double denominator = 0;
+        for (int i = 0; i < n; i++) {
+            double dx = x[i] - meanX;
+            numerator += dx * (y[i] - meanY);
+            denominator += dx * dx;
+        }
+
+        if (denominator == 0) {
+            // All timestamps equal - return average price
+            return BigDecimal.valueOf(meanY).setScale(2, RoundingMode.HALF_UP);
+        }
+
+        double slope = numerator / denominator;
+        double intercept = meanY - slope * meanX;
+
+        double predicted = intercept + slope * date.toEpochSecond(ZoneOffset.UTC);
+        return BigDecimal.valueOf(predicted).setScale(2, RoundingMode.HALF_UP);
+    }
+}


### PR DESCRIPTION
## Summary
- add repository method to fetch price history
- implement `PricePredictionService` using linear regression
- expose `/api/prices/predict` endpoint
- document machine learning feature in README

## Testing
- `mvn -q -pl price-service test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842a35ce120832dac8176274666ecb4